### PR TITLE
Bump watchdog to 0.9.4

### DIFF
--- a/template/java/Dockerfile
+++ b/template/java/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u121-jdk-alpine
 RUN apk add --no-cache curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.6.15/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.4/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl
 


### PR DESCRIPTION
Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>